### PR TITLE
Add missing pheromone type from drop pheromone action

### DIFF
--- a/src/main/java/Interop/Action/DropPheromone.java
+++ b/src/main/java/Interop/Action/DropPheromone.java
@@ -1,9 +1,22 @@
 package Interop.Action;
 
+import Interop.Percept.Smell.SmellPerceptType;
+
 /**
  * This class represents an intention of dropping a pheromone issued by an agent.
  *
  * After a dropping a pheromone an agent will enter a cool down period.
  */
 public final class DropPheromone implements Action, IntruderAction, GuardAction {
+
+    private SmellPerceptType type;
+
+    public DropPheromone(SmellPerceptType type) {
+        this.type = type;
+    }
+
+    public SmellPerceptType getType() {
+        return type;
+    }
+    
 }


### PR DESCRIPTION
It was pointed out that `Interop.Action.DropPheromone` is missing the type of the pheromone.

This pull requests fixes that omission.